### PR TITLE
interaction.commandName search the name variable

### DIFF
--- a/Documentation Searcher/Docs Searcher.js
+++ b/Documentation Searcher/Docs Searcher.js
@@ -18,7 +18,7 @@ module.exports = async function(app, connection, bot, faxstore) {
         ]
         bot.application.commands.create(commands[0], config.discordConfig.guildId).catch(function(err) {console.log(err)});
         bot.on("interactionCreate", async function(interaction) {
-            if(interaction.commandName == "docs") {
+            if(interaction.commandName === commands[0].name) { // could also do commands[0]["name"] but either way works...
                 let query = interaction.options.get("query")?.value;
                 if(query) {
                     let resp = await axios.get(`https://${docsConfig.docsDomain}/api/search?q=${encodeURIComponent(query)}`);


### PR DESCRIPTION
I'd recommend changing it to setting set on line 21 that way, in the event, a user changes the "docs" name value to something else it'll check for that command "name" and == to === since it's just checking for two strings but that doesn't really matter